### PR TITLE
[Refactor] 깃허브 등록 후 깃허브의 회원 정보 db에 저장하기 위해 백엔드에 api요청 보낼 때 헤더에 access token포함시키기

### DIFF
--- a/src/components/OAuthRedirectPage.jsx
+++ b/src/components/OAuthRedirectPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
+import axios from "axios";
 
 const OAuthRedirectPage = () => {
   const [searchParams] = useSearchParams();
@@ -39,11 +40,17 @@ const OAuthRedirectPage = () => {
 
   // ✅ 여기! login 함수 정의
   const registerGihub = async ({ providerId }) => {
+    const accessToken = localStorage.getItem("accessToken");
     try {
       const response = await axios.post(
         "http://localhost:8080/users/register/github",
         {
           providerId,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
         }
       );
       return {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #12

## 📝작업 내용
> 깃허브 등록 후 깃허브의 회원 정보 db에 저장하기 위해 백엔드에 api요청 보낼 때 헤더에 access token포함시키기

## 🔎코드 설명
> OAuthRedirectPage.jsx에서 axios로 백엔드에 api요청 보낼 때 header에 access token 포함시키기

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
